### PR TITLE
Fixing issue with app upload read time out.

### DIFF
--- a/src/main/java/com/browserstack/appautomate/AppAutomateClient.java
+++ b/src/main/java/com/browserstack/appautomate/AppAutomateClient.java
@@ -78,9 +78,8 @@ public class AppAutomateClient extends BrowserStackClient implements AppAutomate
 
       BrowserStackRequest request = newRequest(Method.POST, "/upload");
 	  // Setting read timeout to 0(infinity), as for large files it takes a lot of time.
-	  request.getHttpRequest().setReadTimeout(0);
-	  
-	  AppUploadResponse appUploadResponse = request.body(content).asObject(AppUploadResponse.class);
+      request.getHttpRequest().setReadTimeout(0);
+      AppUploadResponse appUploadResponse = request.body(content).asObject(AppUploadResponse.class);
 
       if (appUploadResponse == null || Tools.isStringEmpty(appUploadResponse.getAppUrl())) {
         throw new AppAutomateException("App upload failed!", 0);


### PR DESCRIPTION
Setting read timeout equals to zero as it will set read timeout to infinity.
This is being done as earlier it was giving error on uploading large apps.