### PR TITLE
Non-Mandatory Proxy Auth Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # automate-client-java
 
-## For Code formatting
-Code style files are there in code_formatters folder (for eclipse and intellij idea) ,to import formatter instructions are as follows :
-* For Eclipse : Under Window/Preferences select Java/Code Style/Formatter. Import the settings file by selecting Import.
-* For IntelliJ Idea : Settings → Code Style → Java, click Manage, and import that XML file by simply clicking Import.
+<p align="center">
+  <a href="https://browserstack.com"><img alt="BrowserStack Logo" src="https://d98b8t1nnulk5.cloudfront.net/production/images/layout/logo-invoice.svg"></a>
+</p>
+
+Java Package to seamlessly connect with Automate and App-Automate.
+
+## Features
+1. Operations on Projects, Builds & Sessions
+2. Upload App for App-Automate
+3. Account Usage
+4. Reset Key
+

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>com.browserstack</groupId>
 	<artifactId>automate-client-java</artifactId>
 	<name>automate-client</name>
-	<version>0.6</version>
+	<version>0.7</version>
 	<packaging>jar</packaging>
 	<description>Java bindings for BrowserStack Automate REST API</description>
     <url>https://www.browserstack.com</url>

--- a/src/main/java/com/browserstack/client/BrowserStackClient.java
+++ b/src/main/java/com/browserstack/client/BrowserStackClient.java
@@ -33,7 +33,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;

--- a/src/main/java/com/browserstack/client/BrowserStackClient.java
+++ b/src/main/java/com/browserstack/client/BrowserStackClient.java
@@ -176,7 +176,7 @@ public abstract class BrowserStackClient implements BrowserStackClientInterface 
         }
 
         final HttpClient client = clientBuilder.build();
-        this.HTTP_TRANSPORT = new ApacheHttpTransport(client);
+        HTTP_TRANSPORT = new ApacheHttpTransport(client);
         this.requestFactory = newRequestFactory();
     }
 

--- a/src/main/java/com/browserstack/client/BrowserStackClient.java
+++ b/src/main/java/com/browserstack/client/BrowserStackClient.java
@@ -156,7 +156,7 @@ public abstract class BrowserStackClient implements BrowserStackClientInterface 
      * @param proxyPassword password of the proxy
      */
 
-    public void setProxy(@Nonnull final String proxyHost, @Nonnull final int proxyPort, @Nullable final String proxyUsername, @Nullable final String proxyPassword) {
+    public void setProxy(final String proxyHost, final int proxyPort, final String proxyUsername, final String proxyPassword) {
 
         if (proxyHost == null || proxyPort == 0) {
             return;

--- a/src/main/java/com/browserstack/client/BrowserStackClient.java
+++ b/src/main/java/com/browserstack/client/BrowserStackClient.java
@@ -172,12 +172,11 @@ public abstract class BrowserStackClient implements BrowserStackClientInterface 
                     new UsernamePasswordCredentials(proxyUsername, proxyPassword);
             basicCredentialsProvider.setCredentials(proxyAuthScope, proxyAuthentication);
 
-            clientBuilder = clientBuilder.setDefaultCredentialsProvider(basicCredentialsProvider);
+            clientBuilder.setDefaultCredentialsProvider(basicCredentialsProvider);
         }
 
         final HttpClient client = clientBuilder.build();
-        final ApacheHttpTransport transport = new ApacheHttpTransport(client);
-        this.HTTP_TRANSPORT = transport;
+        this.HTTP_TRANSPORT = new ApacheHttpTransport(client);
         this.requestFactory = newRequestFactory();
     }
 


### PR DESCRIPTION
Make the auth params of Proxy non-mandatory to allow utilizing proxies without auth requirements.

Parent task: https://browserstack.atlassian.net/browse/ACE-1568