### PR TITLE
Aps 7938 cli version logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
 				</executions>
 			</plugin>
 		</plugins>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 	</build>
 
 	<dependencies>

--- a/src/main/java/com/browserstack/client/BrowserStackRequest.java
+++ b/src/main/java/com/browserstack/client/BrowserStackRequest.java
@@ -19,7 +19,8 @@ import java.util.regex.Pattern;
 
 public class BrowserStackRequest {
 
-    private static final String USER_AGENT = "browserstack-automate-java/1.0";
+    private static final String releaseVersion = (getReleaseProperties("release.version") != null) ? getReleaseProperties("release.version") : "1.0";
+    private static final String USER_AGENT = "browserstack-automate-java/"+releaseVersion;
     private final HttpRequest httpRequest;
 
     public BrowserStackRequest(HttpRequest httpRequest) {
@@ -40,6 +41,23 @@ public class BrowserStackRequest {
         }
 
         return result.toString("UTF-8");
+    }
+
+    private static String getReleaseProperties(String key) {
+        Properties properties = new Properties();
+        try (InputStream input = BrowserStackRequest.class.getClassLoader().getResourceAsStream("release.properties")) {
+            if (input != null) {
+                properties.load(input);
+                String releaseVersion = properties.getProperty("release.version");
+                System.out.println("HARI DEBUG Release Version: " + releaseVersion);
+                return releaseVersion;
+            } else {
+                System.err.println("HARI DEBUG version.properties not found");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public BrowserStackRequest header(String name, String value) {

--- a/src/main/java/com/browserstack/client/BrowserStackRequest.java
+++ b/src/main/java/com/browserstack/client/BrowserStackRequest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,10 +50,7 @@ public class BrowserStackRequest {
             if (input != null) {
                 properties.load(input);
                 String releaseVersion = properties.getProperty("release.version");
-                System.out.println("HARI DEBUG Release Version: " + releaseVersion);
                 return releaseVersion;
-            } else {
-                System.err.println("HARI DEBUG version.properties not found");
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/resources/release.properties
+++ b/src/main/resources/release.properties
@@ -1,0 +1,1 @@
+release.version=@project.version@


### PR DESCRIPTION
Description:
- Currently there are no ways to identify the current version used by the user.
- Instrumenting our cli version in user agent to use this for debugging and other purposes.

![image](https://github.com/browserstack/automate-client-java/assets/108120462/ae97e0ea-1ea4-4768-bfc2-6f605337d970)

